### PR TITLE
Rework CacheManager construction and allow dynamic creation

### DIFF
--- a/src/integration/java/com/couchbase/client/spring/cache/wiring/CacheEnabledTestConfiguration.java
+++ b/src/integration/java/com/couchbase/client/spring/cache/wiring/CacheEnabledTestConfiguration.java
@@ -15,9 +15,8 @@
  */
 package com.couchbase.client.spring.cache.wiring;
 
-import java.util.Collections;
-
 import com.couchbase.client.spring.cache.CouchbaseCacheManager;
+import com.couchbase.client.spring.cache.CacheBuilder;
 import com.couchbase.client.spring.cache.TestConfiguration;
 
 import org.springframework.cache.CacheManager;
@@ -41,6 +40,6 @@ public class CacheEnabledTestConfiguration extends TestConfiguration {
 
   @Bean
   public CacheManager cacheManager() {
-    return new CouchbaseCacheManager(Collections.singletonMap(DATA_CACHE_NAME, bucket()));
+    return new CouchbaseCacheManager(CacheBuilder.newInstance(bucket()), DATA_CACHE_NAME);
   }
 }

--- a/src/main/java/com/couchbase/client/spring/cache/CacheBuilder.java
+++ b/src/main/java/com/couchbase/client/spring/cache/CacheBuilder.java
@@ -1,0 +1,63 @@
+package com.couchbase.client.spring.cache;
+
+import com.couchbase.client.java.Bucket;
+
+/**
+ * A builder for {@link CouchbaseCache} instance.
+ *
+ * @author Simon Baslé
+ */
+public class CacheBuilder {
+
+  private static final int DEFAULT_TTL = 0;
+
+  private Bucket bucket;
+  private int cacheExpiry;
+
+  protected CacheBuilder() {
+    this.cacheExpiry = DEFAULT_TTL;
+  }
+
+  /**
+   * Create a new builder instance with the given {@link Bucket}.
+   * @param bucket the bucket to use
+   * @return a new builder
+   */
+  public static CacheBuilder newInstance(Bucket bucket) {
+    return new CacheBuilder().withBucket(bucket);
+  }
+
+  /**
+   * Give a bucket to the cache to be built.
+   * @param bucket the bucket
+   * @return this builder for chaining.
+   */
+  public CacheBuilder withBucket(Bucket bucket) {
+    if (bucket == null) {
+      throw new NullPointerException("A non-null Bucket is required for all cache builders");
+    }
+    this.bucket = bucket;
+    return this;
+  }
+
+  /**
+   * Give a default expiration (or TTL) to the cache to be built.
+   *
+   * @param expiration the expiration delay in milliseconds.
+   * @return this builder for chaining.
+   */
+  public CacheBuilder withExpirationInMillis(int expiration) {
+    this.cacheExpiry = expiration;
+    return this;
+  }
+
+  /**
+   * Build a new {@link CouchbaseCache} with the specified name.
+   * @param cacheName the name of the cache
+   * @return a {@link CouchbaseCache} instance
+   */
+  public CouchbaseCache build(String cacheName) {
+    return new CouchbaseCache(cacheName, this.bucket, this.cacheExpiry);
+  }
+
+}


### PR DESCRIPTION
This change reworks the constructor of `CouchbaseCacheManager` so that
it is easier to create in the 80% case, without having to provide a Map.

One can now create a manager with a statically declared list of caches
in 3 ways:

 * just provide the names and the `Bucket` to use (expected 80% case)
 * provide names, bucket and a common non-zero ttl for all caches
 * provide a map of names and custom distinct ttls + the bucket for case
   where you need static declaration but distinct expirations.

Furthermore, dynamic creation of caches is now allowed. After having
constructed the `CouchbaseCacheManager` without a list of cache names,
one can request any cache and it will be created with the currently set
`defaultTtl` (which can be changed between cache requests).

Closes #4