### PR TITLE
Update usage section of readme to use new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ Instantiate a `CouchbaseCacheManager` using `CacheBuilder` to either create seve
 
 ```java
 //preloaded cache manager, same configs
-new CouchbaseCacheManager(new CacheBuilder().withBucket(bucket), "cache1", "cache2");
+new CouchbaseCacheManager(CacheBuilder.newInstance(bucket), "cache1", "cache2");
 
 //preloaded cache manager, custom configs
 Map<String, CacheBuilder> caches = new HashMap<String, CacheBuilder>();
-caches.put("cacheA", new CacheBuilder().withBucket(bucket).withExpirationInMillis(2000));
-caches.put("cacheB", new CacheBuilder().withBucket(bucket2).withExpirationInMillis(3000));
+caches.put("cacheA", CacheBuilder.newInstance(bucket).withExpiration(2));
+caches.put("cacheB", CacheBuilder.newInstance(bucket2).withExpiration(3));
 new CouchbaseCacheManager(caches);
 
 //dynamic-capable cache manager
 //no cache is preloaded but it will create them on demand using the builder as a template
-new CouchbaseCacheManager(new CacheBuilder().withBucket(bucket).withExpirationInMillis(1000));
+new CouchbaseCacheManager(CacheBuilder.newInstance(bucket).withExpiration(1));
 ```
 
 Notice how the `CacheBuilder` allows you to describe how the `Cache` is backed by Couchbase by providing a `Bucket` from the Couchbase Java SDK, among other tunings.


### PR DESCRIPTION
The constructor for `com.couchbase.client.spring.cache.CacheBuilder` is
now protected so `newInstance(Bucket)` static method should be used
instead. Also, `withExpirationInMillis` has been deprecated in favour of
`withExpiration` which uses seconds as units.