### PR TITLE
Reactive couchbase springboot cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ Notice how the `CacheBuilder` allows you to describe how the `Cache` is backed b
 
 Note that for now **only buckets of type "`couchbase`" are supported**, so that several caches can be created over the same `Bucket` and still cleared independently.
 
+## Reactive Usage
+Instantiate a `ReactiveCouchbaseCacheManager` using `ReactiveCacheBuilder` to either create several caches sharing the same template or a map of builders to individually customize several preloaded caches.
+
+```java
+//preloaded cache manager, same configs
+new ReactiveCouchbaseCacheManager(new ReactiveCacheBuilder().withBucket(bucket), "cache1", "cache2");
+
+//preloaded cache manager, custom configs
+Map<String, ReactiveCacheBuilder> caches = new HashMap<String, ReactiveCacheBuilder>();
+caches.put("cacheA", new ReactiveCacheBuilder().withBucket(bucket).withExpiration(2));
+caches.put("cacheB", new ReactiveCacheBuilder().withBucket(bucket2).withExpiration(3));
+new ReactiveCouchbaseCacheManager(caches);
+
+//dynamic-capable cache manager
+//no cache is preloaded but it will create them on demand using the builder as a template
+new ReactiveCouchbaseCacheManager(new ReactiveCacheBuilder().withBucket(bucket).withExpiration(1));
+```
+
 ## How to get it: how to build
 Release 2.0.0 is available on Maven Central. Edit your `pom.xml` and add the following dependency in the `dependencies` section:
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <spring.version>4.3.5.RELEASE</spring.version>
         <couchbase.version>2.3.6</couchbase.version>
         <slf4j.version>1.7.10</slf4j.version>
+        <reactor.version>3.2.11.RELEASE</reactor.version>
 
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
@@ -71,6 +72,13 @@
             <artifactId>java-client</artifactId>
             <version>${couchbase.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>${reactor.version}</version>
+        </dependency>
+
 
         <dependency>
             <groupId>junit</groupId>

--- a/src/integration/java/com/couchbase/client/spring/cache/TestConfiguration.java
+++ b/src/integration/java/com/couchbase/client/spring/cache/TestConfiguration.java
@@ -38,7 +38,7 @@ public class TestConfiguration {
     return System.getProperty("couchbase.bucketName", "default");
   }
   public String bucketPassword() {
-    return System.getProperty("couchbase.bucketPassword", "");
+    return System.getProperty("couchbase.bucketPassword", "password1");
   }
 
   @Bean(destroyMethod = "disconnect")

--- a/src/integration/java/com/couchbase/client/spring/cache/TestConfiguration.java
+++ b/src/integration/java/com/couchbase/client/spring/cache/TestConfiguration.java
@@ -38,7 +38,7 @@ public class TestConfiguration {
     return System.getProperty("couchbase.bucketName", "default");
   }
   public String bucketPassword() {
-    return System.getProperty("couchbase.bucketPassword", "password1");
+    return System.getProperty("couchbase.bucketPassword", "");
   }
 
   @Bean(destroyMethod = "disconnect")

--- a/src/integration/java/com/couchbase/client/spring/cache/reactive/ReactiveCouchbaseCacheManagerTests.java
+++ b/src/integration/java/com/couchbase/client/spring/cache/reactive/ReactiveCouchbaseCacheManagerTests.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) 2015 Couchbase Inc., the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.client.spring.cache.reactive;
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.spring.cache.TestConfiguration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Verifies the correct functionality of the CouchbaseCacheManager,
+ * loading a static set of caches at initialization or dynamically creating caches.
+ *
+ * @author Michael Nitschinger
+ * @author Simon Baslé
+ * @author Stéphane Nicoll
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = TestConfiguration.class)
+public class ReactiveCouchbaseCacheManagerTests {
+    
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+    
+    /**
+     * Contains a reference to the actual underlying {@link Bucket}.
+     */
+    @Autowired
+    private Bucket client;
+    
+    private ReactiveCacheBuilder defaultCacheBuilder;
+    
+    @Before
+    public void setup() {
+        this.defaultCacheBuilder = ReactiveCacheBuilder.newInstance(client);
+    }
+    
+    /**
+     * Test statically declaring and loading a cache with default expiry.
+     */
+    @Test
+    public void testCacheInit() {
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(defaultCacheBuilder, "test");
+        manager.afterPropertiesSet();
+        
+        assertThat(manager.getCacheNames(), hasItems("test"));
+        assertThat(manager.getCacheNames().size(), equalTo(1));
+        assertCache(manager, "test", client, 0); // default TTL value
+    }
+    
+    /**
+     * Test statically declaring and loading a cache won't allow for dynamic creation later
+     */
+    @Test
+    public void testStaticCacheInitOnlyCreatesKnownCaches() {
+        
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(defaultCacheBuilder,
+                "test");
+        manager.afterPropertiesSet();
+        
+        assertThat(manager.getCacheNames(), hasItems("test"));
+        assertThat(manager.getCacheNames().size(), equalTo(1));
+        
+        Cache cache = manager.getCache("test");
+        assertNotNull(cache);
+        
+        Cache invalidCache = manager.getCache("invalid");
+        assertNull(invalidCache);
+        assertThat(manager.getCacheNames(), hasItems("test"));
+        assertThat(manager.getCacheNames().size(), equalTo(1));
+    }
+    
+    /**
+     * Test statically declaring and loading 2 caches with a common non-zero TTL value.
+     */
+    @Test
+    public void testCacheInitWithCommonTtl() {
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(
+                defaultCacheBuilder.withExpiration(100), "cache1", "cache2");
+        manager.afterPropertiesSet();
+        
+        assertThat(manager.getCacheNames(), hasItems("cache1", "cache2"));
+        assertThat(manager.getCacheNames().size(), equalTo(2));
+        
+        assertCache(manager, "cache1", client, 100);
+        assertCache(manager, "cache2", client, 100);
+    }
+    
+    /**
+     * Test statically declaring and loading 2 caches with custom TTL values.
+     */
+    @Test
+    public void testCacheInitWithCustomTtl() {
+        Map<String, ReactiveCacheBuilder> cacheConfigs = new LinkedHashMap<String, ReactiveCacheBuilder>();
+        cacheConfigs.put("cache1", ReactiveCacheBuilder.newInstance(client).withExpiration(100));
+        cacheConfigs.put("cache2", ReactiveCacheBuilder.newInstance(client).withExpiration(200));
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(cacheConfigs);
+        manager.afterPropertiesSet();
+        
+        assertThat(manager.getCacheNames(), hasItems("cache1", "cache2"));
+        assertThat(manager.getCacheNames().size(), equalTo(2));
+        
+        assertCache(manager, "cache1", client, 100);
+        assertCache(manager, "cache2", client, 200);
+    }
+    
+    @Test
+    public void testCacheInitWithSingleConfig() {
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(
+                Collections.singletonMap("test",
+                        ReactiveCacheBuilder.newInstance(client).withExpiration(100)));
+        
+        manager.afterPropertiesSet();
+        
+        assertThat(manager.getCacheNames(), hasItems("test"));
+        assertThat(manager.getCacheNames().size(), equalTo(1));
+        
+        assertCache(manager, "test", client, 100);
+    }
+    
+    @Test
+    public void testCacheInitWithSingleConfigAndNoTtl() {
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(
+                Collections.singletonMap("test",
+                        ReactiveCacheBuilder.newInstance(client)));
+        //null ttl in config should result in using the default ttl's value at afterPropertiesSet
+        manager.afterPropertiesSet();
+        
+        assertThat(manager.getCacheNames(), hasItems("test"));
+        assertThat(manager.getCacheNames().size(), equalTo(1));
+        assertCache(manager, "test", client, 0);
+    }
+    
+    @Test
+    public void testCacheInitWithThreeConfigs() {
+        Map<String, ReactiveCacheBuilder> cacheConfigs = new LinkedHashMap<String, ReactiveCacheBuilder>();
+        cacheConfigs.put("cache1", ReactiveCacheBuilder.newInstance(client).withExpiration(100));
+        cacheConfigs.put("cache2", ReactiveCacheBuilder.newInstance(client).withExpiration(200));
+        cacheConfigs.put("cache3", ReactiveCacheBuilder.newInstance(client).withExpiration(300));
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(cacheConfigs);
+        
+        manager.afterPropertiesSet();
+        
+        assertThat(manager.getCacheNames(), hasItems("cache1", "cache2", "cache3"));
+        assertThat(manager.getCacheNames().size(), equalTo(3));
+        assertCache(manager, "cache1", client, 100);
+        assertCache(manager, "cache2", client, 200);
+        assertCache(manager, "cache3", client, 300);
+    }
+    
+    @Test
+    public void testCacheInitWithConfigIgnoresDuplicates() {
+        Map<String, ReactiveCacheBuilder> cacheConfigs = new LinkedHashMap<String, ReactiveCacheBuilder>();
+        cacheConfigs.put("test", ReactiveCacheBuilder.newInstance(client).withExpiration(100));
+        cacheConfigs.put("test", ReactiveCacheBuilder.newInstance(client).withExpiration(200));
+        cacheConfigs.put("test", ReactiveCacheBuilder.newInstance(client).withExpiration(300));
+        
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(cacheConfigs);
+        manager.afterPropertiesSet();
+        
+        assertThat(manager.getCacheNames(), hasItems("test"));
+        assertThat(manager.getCacheNames().size(), equalTo(1));
+        assertCache(manager, "test", client, 300);
+    }
+    
+    @Test
+    public void testCacheInitWithConfigIgnoresNullVararg() {
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(
+                defaultCacheBuilder.withExpiration(400));
+        manager.afterPropertiesSet();
+        
+        assertThat(manager.getCacheNames().size(), equalTo(0));
+        manager.getCache("test");
+        
+        assertThat(manager.getCacheNames(), hasItems("test"));
+        assertThat(manager.getCacheNames().size(), equalTo(1));
+        assertCache(manager, "test", client, 400);
+    }
+    
+    /**
+     * Test dynamic cache creation, with changing default ttl.
+     */
+    @Test
+    public void testDynamicCacheInitWithoutTtl() {
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(defaultCacheBuilder);
+        manager.afterPropertiesSet();
+        
+        assertThat(manager.getCacheNames().size(), equalTo(0));
+        manager.getCache("test");
+        
+        assertThat(manager.getCacheNames(), hasItems("test"));
+        assertThat(manager.getCacheNames().size(), equalTo(1));
+        assertCache(manager, "test", client, 0); // default TTL value
+    }
+    
+    @Test
+    public void testDynamicCacheInitWithTtl() {
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(
+                defaultCacheBuilder.withExpiration(20));
+        manager.afterPropertiesSet();
+        Cache expiringCache = manager.getCache("testExpiring");
+        
+        assertNotNull(expiringCache);
+        assertThat(manager.getCacheNames(), hasItems("testExpiring"));
+        assertThat(manager.getCacheNames().size(), equalTo(1));
+        assertCache(manager, "testExpiring", client, 20);
+    }
+    
+    @Test
+    public void disableDynamicMode() {
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(
+                defaultCacheBuilder.withExpiration(20));
+        manager.afterPropertiesSet();
+        
+        manager.setDefaultCacheBuilder(null);
+        
+        assertThat(manager.getCache("dynamicCache"), nullValue());
+        assertThat(manager.getCacheNames().size(), equalTo(0));
+    }
+    
+    @Test
+    public void prepareCache() {
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(
+                defaultCacheBuilder.withExpiration(20));
+        manager.prepareCache("test");
+        manager.afterPropertiesSet();
+        
+        assertThat(manager.getCacheNames(), hasItems("test"));
+        assertThat(manager.getCacheNames().size(), equalTo(1));
+        assertCache(manager, "test", client, 20);
+    }
+    
+    @Test
+    public void prepareCacheNoBuilder() {
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(
+                defaultCacheBuilder.withExpiration(20), "test");
+        
+        thrown.expect(IllegalStateException.class);
+        manager.prepareCache("another");
+    }
+    
+    @Test
+    public void prepareCacheCustomBuilder() {
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(
+                defaultCacheBuilder.withExpiration(20));
+        manager.prepareCache("test", ReactiveCacheBuilder.newInstance(client).withExpiration(400));
+        manager.afterPropertiesSet();
+        
+        assertThat(manager.getCacheNames(), hasItems("test"));
+        assertThat(manager.getCacheNames().size(), equalTo(1));
+        assertCache(manager, "test", client, 400);
+    }
+    
+    @Test
+    public void prepareCacheCacheManagerInitialized() {
+        ReactiveCouchbaseCacheManager manager = new ReactiveCouchbaseCacheManager(
+                defaultCacheBuilder.withExpiration(20));
+        manager.afterPropertiesSet();
+        
+        thrown.expect(IllegalStateException.class);
+        manager.prepareCache("test", ReactiveCacheBuilder.newInstance(client).withExpiration(400));
+    }
+    
+    private static void assertCache(CacheManager cacheManager, String name, Bucket client, int ttl) {
+        Cache actual = cacheManager.getCache(name);
+        assertThat(actual, not(nullValue()));
+        assertThat(actual.getName(), equalTo(name));
+        assertThat(actual, instanceOf(ReactiveCouchbaseCache.class));
+        ReactiveCouchbaseCache couchbaseCache = (ReactiveCouchbaseCache) actual;
+        assertThat(couchbaseCache.getNativeCache(), equalTo(client));
+        assertThat(couchbaseCache.getCouchbaseCache().getTtl(), equalTo(ttl));
+    }
+    
+}

--- a/src/integration/java/com/couchbase/client/spring/cache/reactive/ReactiveCouchbaseCacheTests.java
+++ b/src/integration/java/com/couchbase/client/spring/cache/reactive/ReactiveCouchbaseCacheTests.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C) 2015 Couchbase Inc., the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.couchbase.client.spring.cache.reactive;
+
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.document.JsonDocument;
+import com.couchbase.client.java.document.json.JsonObject;
+import com.couchbase.client.java.error.DocumentDoesNotExistException;
+import com.couchbase.client.spring.cache.TestConfiguration;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache.ValueWrapper;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import reactor.core.publisher.Mono;
+
+import java.io.Serializable;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests the ReactiveCouchbaseCache class and verifies its functionality.
+ *
+ * @author Michael Nitschinger
+ * @author Konrad Król
+ * @author Simon Baslé
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = TestConfiguration.class)
+public class ReactiveCouchbaseCacheTests {
+    
+    /**
+     * Contains a reference to the actual CouchbaseClient.
+     */
+    @Autowired
+    private Bucket client;
+    
+    /**
+     * Simple name of the cache bucket to create.
+     */
+    private String cacheName = "test";
+    
+    /**
+     * Tests the basic Cache construction functionality.
+     */
+    @Test
+    public void testConstruction() {
+        ReactiveCouchbaseCache cache = new ReactiveCouchbaseCache(cacheName, client);
+        
+        assertEquals(cacheName, cache.getName());
+        assertEquals(client, cache.getNativeCache());
+    }
+    
+    /**
+     * Verifies set() and get() of cache objects.
+     */
+    @Test
+    public void testGetSet() {
+        ReactiveCouchbaseCache cache = new ReactiveCouchbaseCache(cacheName, client);
+        
+        String key = "couchbase-cache-test";
+        String value = "Hello World!";
+        cache.put(key, Mono.just(value));
+        
+        String stored = (String) (((Mono) cache.get(key).get())).block();
+        assertNotNull(stored);
+        assertEquals(value, stored);
+    }
+    
+    /**
+     * Verifies set() with TTL value.
+     */
+    @Test
+    public void testSetWithTtl() throws InterruptedException {
+        ReactiveCouchbaseCache cache = new ReactiveCouchbaseCache(cacheName, client, 1); // cache for 1 second
+        
+        String key = "couchbase-cache-test";
+        String value = "Hello World!";
+        cache.put(key, Mono.just(value));
+        
+        // wait for TTL to expire (double time of TTL)
+        Thread.sleep(2000);
+        
+        ValueWrapper stored = cache.get(key);
+        assertNull(stored);
+    }
+    
+    @Test
+    public void testGetSetWithCast() {
+        ReactiveCouchbaseCache cache = new ReactiveCouchbaseCache(cacheName, client);
+        
+        String key = "couchbase-cache-user";
+        User user = new User();
+        user.firstname = "Michael";
+        
+        cache.put(key, Mono.just(user));
+        
+        User loaded = (User) (((Mono) cache.get(key).get())).block();
+        assertNotNull(loaded);
+        assertEquals(user.firstname, loaded.firstname);
+    }
+    
+    /**
+     * Verifies the deletion of cache objects.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testEvict() throws Exception {
+        ReactiveCouchbaseCache cache = new ReactiveCouchbaseCache(cacheName, client);
+        
+        String key = "couchbase-cache-test";
+        String value = "Hello World!";
+        
+        cache.put(key, Mono.just(value));
+        Thread.sleep(10);
+        
+        cache.evict(key);
+        
+        Thread.sleep(10);
+        Object result = cache.get(key);
+        assertNull(result);
+    }
+    
+    /**
+     * Putting into cache on the same key not null value, and then null value,
+     * results in null object
+     */
+    @Test
+    public void testSettingNullAndGetting() {
+        ReactiveCouchbaseCache cache = new ReactiveCouchbaseCache(cacheName, client);
+        
+        String key = "couchbase-cache-test";
+        String value = "Hello World!";
+        
+        cache.put(key, Mono.just(value));
+        cache.put(key, null);
+        
+        assertNull(cache.get(key));
+    }
+    
+    /**
+     * Putting into cache on the same key not null value and then clearing the cache,
+     * results in null object
+     */
+    @Test
+    public void testClearingUsingViewDoesntImpactUnrelatedDocuments() {
+        ReactiveCouchbaseCache cache = new ReactiveCouchbaseCache(cacheName, client);
+        assertFalse("Expected flush to be disabled by default", cache.getCouchbaseCache().getAlwaysFlush());
+        
+        String key = "couchbase-cache-test";
+        String unrelatedId = "randomKey";
+        String value = "Hello World!";
+        
+        cache.getNativeCache().upsert(JsonDocument.create(unrelatedId, JsonObject.empty()));
+        cache.put(key, Mono.just(value));
+        cache.clear();
+        
+        assertNotNull(cache.getNativeCache().remove(unrelatedId));
+        assertNull(cache.get(key));
+    }
+    
+    @Test
+    public void testClearingEmptyNameCacheUsingViewDoesntImpactUnrelatedDocuments() {
+        ReactiveCouchbaseCache cache = new ReactiveCouchbaseCache(null, client);
+        assertFalse("Expected flush to be disabled by default", cache.getCouchbaseCache().getAlwaysFlush());
+        
+        String key = "couchbase-cache-test";
+        String unrelatedId = "randomKey:in:parts";
+        String value = "Hello World!";
+        
+        cache.getNativeCache().upsert(JsonDocument.create(unrelatedId, JsonObject.empty()));
+        cache.put(key, Mono.just(value));
+        cache.clear();
+        
+        assertNotNull(cache.getNativeCache().remove(unrelatedId));
+        assertNull(cache.get(key));
+    }
+    
+    /**
+     * Putting into cache on the same key not null value and then clearing the cache,
+     * results in null object.
+     * <p>
+     * As this is quite a dangerous method of clearing a cache (with side effects, namely it empties the whole
+     * bucket, including unrelated data), this test has been disabled by default. If you're sure it is safe to
+     * execute, comment the @Ignore annotation below.
+     */
+    @Ignore("Flush clearing test disabled, see test comment.")
+    @Test
+    public void testClearingUsingFlushImpactsUnrelatedDocuments() {
+        ReactiveCouchbaseCache cache = new ReactiveCouchbaseCache(cacheName, client);
+        cache.getCouchbaseCache().setAlwaysFlush(true);
+        
+        String key = "couchbase-cache-test";
+        String unrelatedId = "randomKey";
+        String value = "Hello World!";
+        
+        cache.getNativeCache().upsert(JsonDocument.create(unrelatedId, JsonObject.empty()));
+        cache.put(key, Mono.just(value));
+        cache.clear();
+        
+        try {
+            cache.getNativeCache().remove(unrelatedId);
+            fail(unrelatedId + " is expected to have been flushed");
+        } catch (DocumentDoesNotExistException e) {
+            //success
+        }
+        assertNull(cache.get(key));
+    }
+    
+    @Test
+    public void testClearingEmptyCacheUsingViewSucceeds() {
+        ReactiveCouchbaseCache cache = new ReactiveCouchbaseCache("emptyCache", client);
+        String unrelatedId = "unrelated";
+        cache.getNativeCache().upsert(JsonDocument.create(unrelatedId, JsonObject.empty()));
+        
+        try {
+            cache.clear();
+        } catch (NoSuchElementException e) {
+            fail("Cache clearing failed on empty cache: " + e.toString());
+        }
+        assertTrue(cache.getNativeCache().exists(unrelatedId));
+    }
+    
+    @Test
+    public void testCallingSyncGetInParallel() throws ExecutionException, InterruptedException {
+        final String key = "getWithValueLoader";
+        final ReactiveCouchbaseCache cache = new ReactiveCouchbaseCache(cacheName, client);
+        try {
+            cache.evict(key);
+        } catch (DocumentDoesNotExistException e) {
+        }
+        final AtomicInteger count = new AtomicInteger(0);
+        final Callable<Mono<String>> valueLoader = new Callable<Mono<String>>() {
+            @Override
+            public Mono<String> call() throws Exception {
+                return Mono.just("value" + count.getAndIncrement());
+            }
+        };
+        Runnable task = new Runnable() {
+            @Override
+            public void run() {
+                cache.get(key, valueLoader);
+            }
+        };
+        
+        final ExecutorService executorService = Executors.newFixedThreadPool(2);
+        Future<?> future1 = executorService.submit(task);
+        Future<?> future2 = executorService.submit(task);
+        future1.get();
+        future2.get();
+        
+        assertEquals(1, count.get());
+        ValueWrapper w = cache.get(key);
+        assertNotNull(w);
+        assertEquals("value0", ((Mono) w.get()).block());
+    }
+    
+    static class User implements Serializable {
+        public String firstname;
+    }
+    
+}

--- a/src/integration/java/com/couchbase/client/spring/cache/wiring/javaConfig/CouchbaseCacheAnnotationWiringTest.java
+++ b/src/integration/java/com/couchbase/client/spring/cache/wiring/javaConfig/CouchbaseCacheAnnotationWiringTest.java
@@ -15,20 +15,19 @@
  */
 package com.couchbase.client.spring.cache.wiring.javaConfig;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.util.HashSet;
-import java.util.Set;
-
 import com.couchbase.client.spring.cache.wiring.AbstractCouchbaseCacheWiringTest;
 import com.couchbase.client.spring.cache.wiring.CachedService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Test case for the annotation-driven configuration, wiring and execution of a {@link Cacheable}-annotated

--- a/src/integration/java/com/couchbase/client/spring/cache/wiring/javaConfig/reactive/ReactiveCacheEnabledTestConfiguration.java
+++ b/src/integration/java/com/couchbase/client/spring/cache/wiring/javaConfig/reactive/ReactiveCacheEnabledTestConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 Couchbase Inc., the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.couchbase.client.spring.cache.wiring.javaConfig.reactive;
+
+import com.couchbase.client.spring.cache.reactive.ReactiveCacheBuilder;
+import com.couchbase.client.spring.cache.reactive.ReactiveCouchbaseCacheManager;
+import com.couchbase.client.spring.cache.TestConfiguration;
+import com.couchbase.client.spring.cache.wiring.CachedService;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * A test {@link Configuration} that scans for services in the same package and enables caching on them.
+ * Recognizes a single cache named "dataCache".
+ *
+ * @author Simon Baslé
+ */
+@EnableCaching
+@Configuration
+@ComponentScan(basePackageClasses = CachedService.class)
+public class ReactiveCacheEnabledTestConfiguration extends TestConfiguration {
+  
+  public static final String DATA_CACHE_NAME = "dataCache";
+  
+  @Bean
+  public ReactiveCacheBuilder defaultBuilder() {
+    return ReactiveCacheBuilder.newInstance(bucket());
+  }
+  
+  @Bean
+  public ReactiveCouchbaseCacheManager cacheManager() {
+    return new ReactiveCouchbaseCacheManager(defaultBuilder(), DATA_CACHE_NAME);
+  }
+}

--- a/src/integration/java/com/couchbase/client/spring/cache/wiring/javaConfig/reactive/ReactiveCacheEnabledTestConfiguration.java
+++ b/src/integration/java/com/couchbase/client/spring/cache/wiring/javaConfig/reactive/ReactiveCacheEnabledTestConfiguration.java
@@ -15,10 +15,10 @@
  */
 package com.couchbase.client.spring.cache.wiring.javaConfig.reactive;
 
+import com.couchbase.client.spring.cache.TestConfiguration;
 import com.couchbase.client.spring.cache.reactive.ReactiveCacheBuilder;
 import com.couchbase.client.spring.cache.reactive.ReactiveCouchbaseCacheManager;
-import com.couchbase.client.spring.cache.TestConfiguration;
-import com.couchbase.client.spring.cache.wiring.CachedService;
+import com.couchbase.client.spring.cache.wiring.reactive.ReactiveCachedService;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -32,7 +32,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @EnableCaching
 @Configuration
-@ComponentScan(basePackageClasses = CachedService.class)
+@ComponentScan(basePackageClasses = ReactiveCachedService.class)
 public class ReactiveCacheEnabledTestConfiguration extends TestConfiguration {
   
   public static final String DATA_CACHE_NAME = "dataCache";

--- a/src/integration/java/com/couchbase/client/spring/cache/wiring/javaConfig/reactive/ReactiveCouchbaseCacheAnnotationWiringTest.java
+++ b/src/integration/java/com/couchbase/client/spring/cache/wiring/javaConfig/reactive/ReactiveCouchbaseCacheAnnotationWiringTest.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.couchbase.client.spring.cache.wiring.xml;
+package com.couchbase.client.spring.cache.wiring.javaConfig.reactive;
 
-import com.couchbase.client.spring.cache.wiring.AbstractCouchbaseCacheWiringTest;
 import com.couchbase.client.spring.cache.wiring.CachedService;
+import com.couchbase.client.spring.cache.wiring.reactive.ReactiveAbstractCouchbaseCacheWiringTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.cache.annotation.Cacheable;
@@ -30,14 +30,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * Test case for the xml driven configuration, wiring and execution of a {@link Cacheable}-annotated
+ * Test case for the annotation-driven configuration, wiring and execution of a {@link Cacheable}-annotated
  * {@link CachedService}.
  *
  * @author Simon Baslé
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration({ "test-manager-context.xml"})
-public class CouchbaseCacheXmlWiringTest extends AbstractCouchbaseCacheWiringTest {
+@ContextConfiguration(classes = ReactiveCacheEnabledTestConfiguration.class)
+public class ReactiveCouchbaseCacheAnnotationWiringTest extends ReactiveAbstractCouchbaseCacheWiringTest {
 
   @Test
   public void testBeans() {
@@ -49,9 +49,6 @@ public class CouchbaseCacheXmlWiringTest extends AbstractCouchbaseCacheWiringTes
     assertNotNull(cacheManager);
 
     Set<String> expectedCaches = new HashSet<String>(3);
-    expectedCaches.add("staticCache1");
-    expectedCaches.add("staticCache2");
-    expectedCaches.add("staticCache3");
     expectedCaches.add("dataCache");
     assertEquals(expectedCaches, cacheManager.getCacheNames());
   }

--- a/src/integration/java/com/couchbase/client/spring/cache/wiring/reactive/ReactiveAbstractCouchbaseCacheWiringTest.java
+++ b/src/integration/java/com/couchbase/client/spring/cache/wiring/reactive/ReactiveAbstractCouchbaseCacheWiringTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2015 Couchbase Inc., the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.couchbase.client.spring.cache.wiring.reactive;
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.spring.cache.reactive.ReactiveCacheBuilder;
+import com.couchbase.client.spring.cache.reactive.ReactiveCouchbaseCacheManager;
+import com.couchbase.client.spring.cache.wiring.CachedService;
+import com.couchbase.client.spring.cache.wiring.javaConfig.CacheEnabledTestConfiguration;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.interceptor.SimpleKey;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Common test case for the wiring and execution of a {@link Cacheable}-annotated {@link CachedService}.
+ *
+ * @author Simon Baslé
+ */
+public abstract class ReactiveAbstractCouchbaseCacheWiringTest {
+    
+    @Autowired
+    public Cluster cluster;
+    
+    @Autowired
+    public Bucket bucket;
+    
+    @Autowired
+    public ReactiveCacheBuilder defaultBuilder;
+    
+    @Autowired
+    public ReactiveCouchbaseCacheManager cacheManager;
+    
+    @Autowired
+    public ReactiveCachedService service;
+    
+    @After
+    public void cleanCache() {
+        Cache cache = cacheManager.getCache(CacheEnabledTestConfiguration.DATA_CACHE_NAME);
+        cache.clear();
+    }
+    
+    @Test
+    public void testCachingOccurs() {
+        service.resetCounters();
+        assertEquals(0L, service.getCounterGetData());
+        
+        ReactiveCachedService.Data data = service.getData("toto", "abc").block();
+        assertNotNull(data);
+        assertEquals(1L, service.getCounterGetData());
+        
+        ReactiveCachedService.Data cachedData = service.getData("toto", "abc").block();
+        assertNotNull(cachedData);
+        assertNotSame(data, cachedData);
+        assertEquals(data, cachedData);
+        assertEquals(1L, service.getCounterGetData());
+        
+        SimpleKey cacheKey = new SimpleKey("toto", "abc");
+        String expectedCouchbaseKey = cbKey(cacheKey);
+        assertTrue(bucket.exists(expectedCouchbaseKey));
+    }
+    
+    @Test
+    public void testCachingWithSpecificKeyOccursIfUnlessNotMet() {
+        String criteriaA = "tata";
+        String criteriaB = "abcdef";
+        int size = 8;
+        
+        service.resetCounters();
+        ReactiveCachedService.Data data = service.getDataWithSize(criteriaA, criteriaB, size).block();
+        ReactiveCachedService.Data cachedData = service.getDataWithSize(criteriaA, criteriaB, size).block();
+        
+        assertNotSame(data, cachedData);
+        assertEquals(data, cachedData);
+        assertEquals(1, service.getCounterGetDataWithSize());
+        
+        SimpleKey unexpectedCacheKey = new SimpleKey(criteriaA, criteriaB, size);
+        String unexpectedCouchbaseKey = cbKey(unexpectedCacheKey);
+        String expectedCouchbaseKey = cbKey(criteriaA);
+        assertFalse("data was wrongfully cached with a generic key " + unexpectedCouchbaseKey, bucket.exists(unexpectedCouchbaseKey));
+        assertTrue("data was not cached with the specific key " + expectedCouchbaseKey, bucket.exists(expectedCouchbaseKey));
+    }
+    
+    @Test
+    public void testCachingWithSpecificKeyDoesntOccurIfUnlessMet() {
+        String criteriaA = "tataTooShort";
+        String criteriaB = "abcdef";
+        int size = 3;
+        
+        service.resetCounters();
+        ReactiveCachedService.Data data = service.getDataWithSize(criteriaA, criteriaB, size).block();
+        ReactiveCachedService.Data cachedData = service.getDataWithSize(criteriaA, criteriaB, size).block();
+        
+        assertNotSame(data, cachedData);
+        assertEquals(data, cachedData);
+        assertEquals(2, service.getCounterGetDataWithSize());
+        
+        SimpleKey unexpectedCacheKey = new SimpleKey(criteriaA, criteriaB, size);
+        String unexpectedCouchbaseKey = cbKey(unexpectedCacheKey);
+        String expectedCouchbaseKey = cbKey(criteriaA);
+        assertFalse("data was wrongfully cached with a generic key " + unexpectedCouchbaseKey, bucket.exists(unexpectedCouchbaseKey));
+        assertFalse("data was wrongfully cached with the specific key " + expectedCouchbaseKey, bucket.exists(expectedCouchbaseKey));
+    }
+    
+    @Test
+    public void testCachingWithKeyThenEvict() {
+        String cacheKey = "cacheThenEvict";
+        String criteriaB = "irrelevant";
+        int size = 100;
+        
+        service.resetCounters();
+        ReactiveCachedService.Data data = service.getDataWithSize(cacheKey, criteriaB, size).block();
+        
+        assertTrue(bucket.exists(cbKey(cacheKey)));
+        
+        service.getDataWithSize(cacheKey, criteriaB, size);
+        
+        assertEquals(1, service.getCounterGetDataWithSize());
+        
+        service.store(data);
+        
+        assertFalse("Data wasn't evicted from cache", bucket.exists(cbKey(cacheKey)));
+    }
+    
+    @Test
+    public void testCacheableMethodWithUnknownCacheNameFails() {
+        try {
+            service.getDataWrongCache("criteria");
+            fail("Cacheable method with unknown cache name expected to fail");
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage() == null || !e.getMessage().contains("Cannot find cache named 'wrongCache'")) {
+                fail("Expected IllegalArgumentException to state it cannot find cache named 'wrongCache'");
+            }
+        }
+    }
+    
+    @Test(expected = RuntimeException.class)
+    public void testDataWithError() {
+        
+        ReactiveCachedService.Data data = service.getDataWithError("key").block();
+    }
+    
+    
+    private static String cbKey(Object cacheKey) {
+        return "cache:" + CacheEnabledTestConfiguration.DATA_CACHE_NAME
+                + ":" + String.valueOf(cacheKey);
+    }
+}

--- a/src/integration/java/com/couchbase/client/spring/cache/wiring/reactive/ReactiveAbstractCouchbaseCacheWiringTest.java
+++ b/src/integration/java/com/couchbase/client/spring/cache/wiring/reactive/ReactiveAbstractCouchbaseCacheWiringTest.java
@@ -21,6 +21,7 @@ import com.couchbase.client.spring.cache.reactive.ReactiveCacheBuilder;
 import com.couchbase.client.spring.cache.reactive.ReactiveCouchbaseCacheManager;
 import com.couchbase.client.spring.cache.wiring.CachedService;
 import com.couchbase.client.spring.cache.wiring.javaConfig.CacheEnabledTestConfiguration;
+import com.couchbase.client.spring.cache.wiring.javaConfig.reactive.ReactiveCacheEnabledTestConfiguration;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -165,7 +166,7 @@ public abstract class ReactiveAbstractCouchbaseCacheWiringTest {
     
     
     private static String cbKey(Object cacheKey) {
-        return "cache:" + CacheEnabledTestConfiguration.DATA_CACHE_NAME
+        return "cache:" + ReactiveCacheEnabledTestConfiguration.DATA_CACHE_NAME
                 + ":" + String.valueOf(cacheKey);
     }
 }

--- a/src/integration/java/com/couchbase/client/spring/cache/wiring/reactive/ReactiveCachedService.java
+++ b/src/integration/java/com/couchbase/client/spring/cache/wiring/reactive/ReactiveCachedService.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2015 Couchbase Inc., the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.couchbase.client.spring.cache.wiring.reactive;
+
+import com.couchbase.client.spring.cache.CouchbaseCache;
+import com.couchbase.client.spring.cache.wiring.javaConfig.reactive.ReactiveCacheEnabledTestConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+import java.io.Serializable;
+
+/**
+ * A test Service with {@link Cacheable} methods to demo and test the wiring of a {@link CouchbaseCache}.
+ *
+ * @author Simon Baslé
+ */
+@Repository
+public class ReactiveCachedService {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReactiveCachedService.class);
+    
+    private long counterGetData = 0L;
+    private long counterGetDataWithSize = 0L;
+    private long counterGetDataWrongCache = 0L;
+    
+    @Cacheable(ReactiveCacheEnabledTestConfiguration.DATA_CACHE_NAME)
+    public Mono<Data> getData(String criteriaA, String criteriaB) {
+        counterGetData++;
+        LOGGER.info("Calling getData {} {} ", criteriaA, criteriaB);
+        return Mono.just(new Data(criteriaA, criteriaB, criteriaA.length()));
+    }
+    
+    @Cacheable(value = ReactiveCacheEnabledTestConfiguration.DATA_CACHE_NAME,
+            key = "#criteriaA", unless = "#size < 5")
+    public Mono<Data> getDataWithSize(String criteriaA, String criteriaB, int size) {
+        counterGetDataWithSize++;
+        LOGGER.info("Calling getDataWithSize {} {} {}", criteriaA, criteriaB, size);
+        return Mono.just(new Data(criteriaA, criteriaB, size));
+    }
+    
+    @CacheEvict(value = ReactiveCacheEnabledTestConfiguration.DATA_CACHE_NAME,
+            key = "#data.valueA")
+    public void store(Data data) {
+        LOGGER.info("Persisted {} to disk", data);
+    }
+    
+    @Cacheable("wrongCache")
+    public Mono<Data> getDataWrongCache(String criteria) {
+        counterGetDataWrongCache++;
+        LOGGER.info("Calling getDataWrongCache {} ", criteria);
+        return Mono.just(new Data(criteria, criteria.toUpperCase(), 10));
+    }
+    
+    @Cacheable(value = ReactiveCacheEnabledTestConfiguration.DATA_CACHE_NAME)
+    public Mono<Data> getDataWithError(String key) {
+        counterGetData++;
+        LOGGER.info("Calling getDataWithError {}", key);
+        return Mono.error(new RuntimeException("blow up"));
+    }
+    
+    public long getCounterGetData() {
+        return counterGetData;
+    }
+    
+    public long getCounterGetDataWithSize() {
+        return counterGetDataWithSize;
+    }
+    
+    public long getCounterGetDataWrongCache() {
+        return counterGetDataWrongCache;
+    }
+    
+    public void resetCounters() {
+        this.counterGetData = 0L;
+        this.counterGetDataWithSize = 0L;
+        this.counterGetDataWrongCache = 0L;
+    }
+    
+    public static class Data implements Serializable {
+        private static final long serialVersionUID = 101106066653013623L;
+        
+        private String valueA;
+        private String valueB;
+        private int intValue;
+        
+        public Data(String valueA, String valueB, int intValue) {
+            this.valueA = valueA;
+            this.valueB = valueB;
+            this.intValue = intValue;
+        }
+        
+        public String getValueA() {
+            return valueA;
+        }
+        
+        public String getValueB() {
+            return valueB;
+        }
+        
+        public int getIntValue() {
+            return intValue;
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            
+            Data data = (Data) o;
+            
+            if (intValue != data.intValue) return false;
+            if (valueA != null ? !valueA.equals(data.valueA) : data.valueA != null) return false;
+            return !(valueB != null ? !valueB.equals(data.valueB) : data.valueB != null);
+            
+        }
+        
+        @Override
+        public int hashCode() {
+            int result = valueA != null ? valueA.hashCode() : 0;
+            result = 31 * result + (valueB != null ? valueB.hashCode() : 0);
+            result = 31 * result + intValue;
+            return result;
+        }
+        
+        @Override
+        public String toString() {
+            return "Data{" +
+                    "valueA='" + valueA + '\'' +
+                    ", valueB='" + valueB + '\'' +
+                    ", intValue=" + intValue +
+                    '}';
+        }
+    }
+}

--- a/src/integration/java/com/couchbase/client/spring/cache/wiring/xml/reactive/ReactiveCouchbaseCacheXmlWiringTest.java
+++ b/src/integration/java/com/couchbase/client/spring/cache/wiring/xml/reactive/ReactiveCouchbaseCacheXmlWiringTest.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.couchbase.client.spring.cache.wiring.xml;
+package com.couchbase.client.spring.cache.wiring.xml.reactive;
 
-import com.couchbase.client.spring.cache.wiring.AbstractCouchbaseCacheWiringTest;
 import com.couchbase.client.spring.cache.wiring.CachedService;
+import com.couchbase.client.spring.cache.wiring.reactive.ReactiveAbstractCouchbaseCacheWiringTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.cache.annotation.Cacheable;
@@ -36,8 +36,8 @@ import static org.junit.Assert.assertNotNull;
  * @author Simon Baslé
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration({ "test-manager-context.xml"})
-public class CouchbaseCacheXmlWiringTest extends AbstractCouchbaseCacheWiringTest {
+@ContextConfiguration({ "reactive-test-manager-context.xml"})
+public class ReactiveCouchbaseCacheXmlWiringTest extends ReactiveAbstractCouchbaseCacheWiringTest {
 
   @Test
   public void testBeans() {

--- a/src/integration/java/com/couchbase/client/spring/cache/wiring/xml/reactive/reactive-test-manager-context.xml
+++ b/src/integration/java/com/couchbase/client/spring/cache/wiring/xml/reactive/reactive-test-manager-context.xml
@@ -19,13 +19,13 @@
         <constructor-arg index="1" type="java.lang.String" value="password1"/>
     </bean>
 
-    <bean id="couchbaseCacheBuilder" class="com.couchbase.client.spring.cache.CacheBuilder"
+    <bean id="couchbaseCacheBuilder" class="com.couchbase.client.spring.cache.reactive.ReactiveCacheBuilder"
           factory-method="newInstance">
         <constructor-arg type="com.couchbase.client.java.Bucket" ref="couchbaseBucket"/>
     </bean>
 
-    <bean id="cacheManager" class="com.couchbase.client.spring.cache.CouchbaseCacheManager">
-        <constructor-arg type="com.couchbase.client.spring.cache.CacheBuilder" ref="couchbaseCacheBuilder"/>
+    <bean id="cacheManager" class="com.couchbase.client.spring.cache.reactive.ReactiveCouchbaseCacheManager">
+        <constructor-arg type="com.couchbase.client.spring.cache.reactive.ReactiveCacheBuilder" ref="couchbaseCacheBuilder"/>
         <constructor-arg>
             <list>
                 <!-- pre-declare caches you intend to use -->
@@ -37,7 +37,7 @@
         </constructor-arg>
     </bean>
 
-    <bean id="cachedService" class="com.couchbase.client.spring.cache.wiring.CachedService"/>
+    <bean id="cachedService" class="com.couchbase.client.spring.cache.wiring.reactive.ReactiveCachedService"/>
 
     <cache:annotation-driven/>
 

--- a/src/integration/java/com/couchbase/client/spring/cache/wiring/xml/reactive/reactive-test-manager-context.xml
+++ b/src/integration/java/com/couchbase/client/spring/cache/wiring/xml/reactive/reactive-test-manager-context.xml
@@ -16,7 +16,7 @@
           factory-bean="couchbaseCluster" factory-method="openBucket">
         <!-- specify the bucket and password to use -->
         <constructor-arg index="0" type="java.lang.String" value="default"/>
-        <constructor-arg index="1" type="java.lang.String" value="password1"/>
+        <constructor-arg index="1" type="java.lang.String" value=""/>
     </bean>
 
     <bean id="couchbaseCacheBuilder" class="com.couchbase.client.spring.cache.reactive.ReactiveCacheBuilder"

--- a/src/integration/java/com/couchbase/client/spring/cache/wiring/xml/test-manager-context.xml
+++ b/src/integration/java/com/couchbase/client/spring/cache/wiring/xml/test-manager-context.xml
@@ -16,7 +16,7 @@
           factory-bean="couchbaseCluster" factory-method="openBucket">
         <!-- specify the bucket and password to use -->
         <constructor-arg index="0" type="java.lang.String" value="default"/>
-        <constructor-arg index="1" type="java.lang.String" value="password1"/>
+        <constructor-arg index="1" type="java.lang.String" value=""/>
     </bean>
 
     <bean id="couchbaseCacheBuilder" class="com.couchbase.client.spring.cache.CacheBuilder"

--- a/src/main/java/com/couchbase/client/spring/cache/CouchbaseCache.java
+++ b/src/main/java/com/couchbase/client/spring/cache/CouchbaseCache.java
@@ -16,11 +16,6 @@
 
 package com.couchbase.client.spring.cache;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Callable;
-
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.bucket.BucketManager;
 import com.couchbase.client.java.document.Document;
@@ -37,11 +32,15 @@ import com.couchbase.client.java.view.View;
 import com.couchbase.client.java.view.ViewQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+import org.springframework.cache.support.SimpleValueWrapper;
 import rx.Observable;
 import rx.functions.Func1;
 
-import org.springframework.cache.Cache;
-import org.springframework.cache.support.SimpleValueWrapper;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
 
 /**
  * The {@link CouchbaseCache} class implements the Spring {@link Cache} interface on top of Couchbase Server and the
@@ -200,7 +199,7 @@ public class CouchbaseCache implements Cache {
    * a {@link RuntimeException}
    *
    * @param key the key whose associated value is to be returned
-   * @param valueLoader
+   * @param valueLoader valueLoader
    * @return the value to which this cache maps the specified key
    * @throws RuntimeException if the {@code valueLoader} throws an exception
    * @since 4.3

--- a/src/main/java/com/couchbase/client/spring/cache/reactive/ReactiveCacheBuilder.java
+++ b/src/main/java/com/couchbase/client/spring/cache/reactive/ReactiveCacheBuilder.java
@@ -1,0 +1,85 @@
+package com.couchbase.client.spring.cache.reactive;
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.spring.cache.CouchbaseCache;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A builder for {@link CouchbaseCache} instance.
+ *
+ * @author Simon Baslé
+ */
+public class ReactiveCacheBuilder {
+    
+    private static final int DEFAULT_TTL = 0;
+    
+    private Bucket bucket;
+    private int cacheExpiry;
+    
+    protected ReactiveCacheBuilder() {
+        this.cacheExpiry = DEFAULT_TTL;
+    }
+    
+    /**
+     * Create a new builder instance with the given {@link Bucket}.
+     *
+     * @param bucket the bucket to use
+     * @return a new builder
+     */
+    public static ReactiveCacheBuilder newInstance(Bucket bucket) {
+        return new ReactiveCacheBuilder().withBucket(bucket);
+    }
+    
+    /**
+     * Give a bucket to the cache to be built.
+     *
+     * @param bucket the bucket
+     * @return this builder for chaining.
+     */
+    public ReactiveCacheBuilder withBucket(Bucket bucket) {
+        if (bucket == null) {
+            throw new NullPointerException("A non-null Bucket is required for all cache builders");
+        }
+        this.bucket = bucket;
+        return this;
+    }
+    
+    /**
+     * Give a default expiration (or TTL) to the cache to be built.
+     * <p>
+     * This method will convert the given MS to seconds and call {@link #withExpiration(int)}
+     * internally. If you use this method with an expiration less than 1000, it will be 0 and the document will not be
+     * deleted automatically.
+     *
+     * @param expiration the expiration delay in milliseconds.
+     * @return this builder for chaining.
+     * @deprecated use {@link #withExpiration(int)} in seconds instead.
+     */
+    @Deprecated
+    public ReactiveCacheBuilder withExpirationInMillis(int expiration) {
+        return withExpiration((int) TimeUnit.MILLISECONDS.toSeconds(expiration));
+    }
+    
+    /**
+     * Give a default expiration (or TTL) to the cache to be built in seconds.
+     *
+     * @param expiration the expiration delay in in seconds.
+     * @return this builder for chaining purposes.
+     */
+    public ReactiveCacheBuilder withExpiration(int expiration) {
+        this.cacheExpiry = expiration;
+        return this;
+    }
+    
+    /**
+     * Build a new {@link CouchbaseCache} with the specified name.
+     *
+     * @param cacheName the name of the cache
+     * @return a {@link CouchbaseCache} instance
+     */
+    public ReactiveCouchbaseCache build(String cacheName) {
+        return new ReactiveCouchbaseCache(cacheName, this.bucket, this.cacheExpiry);
+    }
+    
+}

--- a/src/main/java/com/couchbase/client/spring/cache/reactive/ReactiveCouchbaseCache.java
+++ b/src/main/java/com/couchbase/client/spring/cache/reactive/ReactiveCouchbaseCache.java
@@ -1,0 +1,209 @@
+package com.couchbase.client.spring.cache.reactive;
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.spring.cache.CouchbaseCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+import org.springframework.cache.support.SimpleValueWrapper;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+
+public class ReactiveCouchbaseCache implements Cache {
+    
+    private static final Logger logger = LoggerFactory.getLogger(ReactiveCouchbaseCache.class);
+    
+    private CouchbaseCache couchbaseCache;
+    
+    /**
+     * Construct the cache and pass in the {@link Bucket} instance.
+     *
+     * @param name   the name of the cache reference.
+     * @param client the Bucket instance.
+     */
+    public ReactiveCouchbaseCache(final String name, final Bucket client) {
+        couchbaseCache = new CouchbaseCache(name, client);
+    }
+    
+    /**
+     * Construct the cache and pass in the {@link Bucket} instance.
+     *
+     * @param name   the name of the cache reference.
+     * @param client the Bucket instance.
+     * @param ttl    TTL value for objects in this cache
+     */
+    public ReactiveCouchbaseCache(final String name, final Bucket client, int ttl) {
+        couchbaseCache = new CouchbaseCache(name, client, ttl);
+    }
+    
+    /**
+     * Returns the name of the cache.
+     *
+     * @return the name of the cache.
+     */
+    @Override
+    public final String getName() {
+        return couchbaseCache.getName();
+    }
+    
+    /**
+     * Returns the underlying SDK {@link Bucket} instance.
+     *
+     * @return the underlying Bucket instance.
+     */
+    @Override
+    public final Bucket getNativeCache() {
+        return couchbaseCache.getNativeCache();
+    }
+    
+    @Override
+    public final ValueWrapper get(final Object key) {
+        ValueWrapper valueWrapper = couchbaseCache.get(key);
+        
+        if (valueWrapper == null) {
+            return null;
+        }
+        
+        Object object = valueWrapper.get();
+        
+        return new SimpleValueWrapper(Mono.just(object));
+    }
+    
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The <code>clazz</code> is expected to be implementing {@link java.io.Serializable}.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public final <T> T get(final Object key, final Class<T> clazz) {
+        throw new IllegalArgumentException("Not implemented yet.");
+    }
+    
+    /**
+     * Return the value to which this cache maps the specified key, obtaining
+     * that value from {@code valueLoader} if necessary. This method provides
+     * a simple substitute for the conventional "if cached, return; otherwise
+     * create, cache and return" pattern.
+     * <p>If possible, implementations should ensure that the loading operation
+     * is synchronized so that the specified {@code valueLoader} is only called
+     * once in case of concurrent access on the same key.
+     * <p>If the {@code valueLoader} throws an exception, it is wrapped in
+     * a {@link RuntimeException}
+     *
+     * @param key         the key whose associated value is to be returned
+     * @param valueLoader callable that is going to be executed only if need to.
+     * @return the value to which this cache maps the specified key
+     * @throws RuntimeException if the {@code valueLoader} throws an exception
+     * @since 4.3
+     */
+    @Override
+    public <T> T get(final Object key, final Callable<T> valueLoader) {
+        ValueWrapper valueWrapper = get(key);
+        if (valueWrapper == null && valueLoader != null) {
+            synchronized (couchbaseCache) {
+                valueWrapper = get(key);
+                if (valueWrapper == null) {
+                    try {
+                        T value = valueLoader.call();
+                        put(key, value);
+                        return value;
+                    } catch (ValueRetrievalException ex) {
+                        throw ex;
+                    } catch (Exception e) {
+                        throw new ValueRetrievalException(key, valueLoader, e);
+                    }
+                }
+            }
+        }
+        
+        if (valueWrapper != null) {
+            return (T) valueWrapper.get();
+        }
+        return null;
+    }
+    
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Values of Mono are expected to be {@link java.io.Serializable}.
+     *
+     * @param key   the Key of the storable object.
+     * @param value the Serializable object to store.
+     */
+    @Override
+    public final void put(final Object key, final Object value) {
+        
+        if (value instanceof Mono) {
+            Mono<Object> mono = (Mono) value;
+            mono
+                    .doOnSuccess(new Consumer<Object>() {
+                        public void accept(Object v) {
+                            couchbaseCache.put(key, v);
+                        }
+                    })
+                    .doOnError(new Consumer<Throwable>() {
+                        public void accept(Throwable throwable) {
+                            // incomming mono is errored out, do nothing with cache.
+                            // we need this handler to prevent 'error no handled' stack trace in the logs.
+                        }
+                    })
+                    .subscribe();
+        } else {
+            couchbaseCache.put(key, value);
+        }
+    }
+    
+    @Override
+    public final void evict(final Object key) {
+        couchbaseCache.evict(key);
+    }
+    
+    /**
+     * Clear the complete cache.
+     */
+    @Override
+    public final void clear() {
+        couchbaseCache.clear();
+    }
+    
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Note that the atomicity in this Couchbase implementation is guaranteed for the insertion part. The detection of
+     * the pre-existing key and thus skipping of the insertion is atomic. However, in such a case a get will have to be
+     * performed to retrieve the pre-existing value. This get is not atomic and could see the key as deleted, in which
+     * case it will return a {@link ValueWrapper} with a null content.
+     */
+    @Override
+    public ValueWrapper putIfAbsent(final Object key, Object value) {
+        if (value instanceof Mono) {
+            
+            Mono<Object> mono = (Mono) value;
+            mono
+                    .doOnSuccess(new Consumer<Object>() {
+                        public void accept(Object v) {
+                            ValueWrapper valueWrapper = couchbaseCache.putIfAbsent(key, v);
+                        }
+                    })
+                    .doOnError(new Consumer<Throwable>() {
+                        public void accept(Throwable throwable) {
+                            // incomming mono is errored out, do nothing with cache.
+                            // we need this handler to prevent 'error no handled' stack trace in the logs.
+                        }
+                    })
+                    .subscribe();
+            
+            return new SimpleValueWrapper(Mono.just(value));
+            
+        } else {
+            return couchbaseCache.putIfAbsent(key, value);
+        }
+    }
+    
+    public CouchbaseCache getCouchbaseCache() {
+        return couchbaseCache;
+    }
+}

--- a/src/main/java/com/couchbase/client/spring/cache/reactive/ReactiveCouchbaseCacheManager.java
+++ b/src/main/java/com/couchbase/client/spring/cache/reactive/ReactiveCouchbaseCacheManager.java
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.couchbase.client.spring.cache;
+package com.couchbase.client.spring.cache.reactive;
 
 import com.couchbase.client.java.Bucket;
+import com.couchbase.client.spring.cache.CouchbaseCache;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.support.AbstractCacheManager;
@@ -32,25 +33,25 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * The {@link CouchbaseCacheManager} orchestrates {@link CouchbaseCache} instances.
- *
+ * The {@link ReactiveCouchbaseCacheManager} orchestrates {@link CouchbaseCache} instances.
+ * 
  * Since more than one current {@link Bucket} connection can be used for caching, the
- * {@link CouchbaseCacheManager} orchestrates and handles them for the Spring {@link Cache} abstraction layer.
+ * {@link ReactiveCouchbaseCacheManager} orchestrates and handles them for the Spring {@link Cache} abstraction layer.
  *
  * @author Michael Nitschinger
  * @author Simon Baslé
  * @author Konrad Król
  * @author Stéphane Nicoll
  */
-public class CouchbaseCacheManager extends AbstractCacheManager {
+public class ReactiveCouchbaseCacheManager extends AbstractCacheManager {
 
-  private CacheBuilder defaultCacheBuilder;
+  private ReactiveCacheBuilder defaultCacheBuilder;
 
   private boolean initialized;
-  private final Map<String, CacheBuilder> initialCaches;
+  private final Map<String, ReactiveCacheBuilder> initialCaches;
 
   /**
-   * Construct a {@link CacheManager} with a "template" {@link CacheBuilder} (at least specifying a backing
+   * Construct a {@link CacheManager} with a "template" {@link ReactiveCacheBuilder} (at least specifying a backing
    * {@link Bucket}).
    *
    * If a list of predetermined cache names is provided, the manager is "static" and these caches will all be
@@ -65,15 +66,15 @@ public class CouchbaseCacheManager extends AbstractCacheManager {
    * caches or later dynamic construction.
    * @param cacheNames the names of caches recognized by this manager initially. If empty, caches can be added
    * dynamically later. Null names will be ignored.
-   * @see CouchbaseCacheManager#setDefaultCacheBuilder(CacheBuilder) to force activation of dynamic creation later on.
+   * @see ReactiveCouchbaseCacheManager#setDefaultCacheBuilder(ReactiveCacheBuilder) to force activation of dynamic creation later on.
    */
-  public CouchbaseCacheManager(CacheBuilder cacheBuilder, String... cacheNames) {
+  public ReactiveCouchbaseCacheManager(ReactiveCacheBuilder cacheBuilder, String... cacheNames) {
     if (cacheBuilder == null) {
-      throw new NullPointerException("CacheBuilder template is mandatory");
+      throw new NullPointerException("ReactiveCacheBuilder template is mandatory");
     }
     Set<String> names = cacheNames.length == 0? Collections.<String> emptySet()
             : new LinkedHashSet<String>(Arrays.asList(cacheNames));
-    this.initialCaches = new HashMap<String, CacheBuilder>(names.size());
+    this.initialCaches = new HashMap<String, ReactiveCacheBuilder>(names.size());
     for (String name : names) {
       if (name != null) {
         this.initialCaches.put(name, cacheBuilder);
@@ -86,18 +87,18 @@ public class CouchbaseCacheManager extends AbstractCacheManager {
 
   /**
    * Construct a {@link CacheManager} knowing about a predetermined set of caches at construction. The caches are
-   * all explicitly described (using a {@link CacheBuilder} and the manager cannot create caches dynamically until
-   * {@link #setDefaultCacheBuilder(CacheBuilder)} is called.
+   * all explicitly described (using a {@link ReactiveCacheBuilder} and the manager cannot create caches dynamically until
+   * {@link #setDefaultCacheBuilder(ReactiveCacheBuilder)} is called.
    *
    * Note that builders are used lazily and should not be mutated after having been passed to this constructor.
    *
    * @param initialCaches the caches to make available on startup
    */
-  public CouchbaseCacheManager(Map<String, CacheBuilder> initialCaches) {
+  public ReactiveCouchbaseCacheManager(Map<String, ReactiveCacheBuilder> initialCaches) {
     if (initialCaches == null || initialCaches.isEmpty()) {
       throw new IllegalArgumentException("At least one cache builder must be specified.");
     }
-    this.initialCaches = new HashMap<String, CacheBuilder>(initialCaches);
+    this.initialCaches = new HashMap<String, ReactiveCacheBuilder>(initialCaches);
   }
 
   /**
@@ -106,7 +107,7 @@ public class CouchbaseCacheManager extends AbstractCacheManager {
    *
    * @param defaultCacheBuilder the cache builder to use
    */
-  public void setDefaultCacheBuilder(CacheBuilder defaultCacheBuilder) {
+  public void setDefaultCacheBuilder(ReactiveCacheBuilder defaultCacheBuilder) {
     this.defaultCacheBuilder = defaultCacheBuilder;
   }
 
@@ -128,7 +129,7 @@ public class CouchbaseCacheManager extends AbstractCacheManager {
 
   /**
    * Register an additional cache with the specified name using the specified
-   * {@link CacheBuilder}.
+   * {@link ReactiveCacheBuilder}.
    * <p>
    * Caches can only be configured at initialization time. Once the cache manager
    * has been initialized, no cache can be further prepared.
@@ -136,7 +137,7 @@ public class CouchbaseCacheManager extends AbstractCacheManager {
    * @param builder builder
    * @throws IllegalStateException the cache manager has already been initialized
    */
-  public void prepareCache(String name, CacheBuilder builder) {
+  public void prepareCache(String name, ReactiveCacheBuilder builder) {
     if (initialized) {
       throw new IllegalStateException("This cache manager has already been initialized. No " +
               "further cache can be prepared.");
@@ -153,7 +154,7 @@ public class CouchbaseCacheManager extends AbstractCacheManager {
   protected final Collection<? extends Cache> loadCaches() {
     initialized = true;
     List<Cache> caches = new LinkedList<Cache>();
-    for (Map.Entry<String, CacheBuilder> entry : initialCaches.entrySet()) {
+    for (Map.Entry<String, ReactiveCacheBuilder> entry : initialCaches.entrySet()) {
       caches.add(entry.getValue().build(entry.getKey()));
     }
     return caches;


### PR DESCRIPTION
With this PR, one is able to cache a value of a Mono. Please see below a sample service that is caching a value of a Mono via Cacheable annotation:

@Service
public class AemFacade {
    
    private static final Logger LOGGER = LoggerFactory.getLogger(AemFacade.class);
    
    private final WebClient webClient;
    
    @Value("${environment.aemUrl}")
    private String aemUrl;
    
    @Autowired
 public AemFacade(WebClient webClient) {
        this.webClient = webClient;
    }
    
    @Cacheable(cacheNames = "media", key = "{ #request.id, #request.mediaType }")
    public Mono<AemResponse> getMedia(AemRequest request) {
        
        LOGGER.debug("executing AemFacade.getMedias({},{}}", request.getId(), request.getMediaType());
        
        String url = aemUrl + buildResourceUri(request);
        
        return webClient
 .get()
                .uri(url)
                .retrieve()
                .bodyToMono(AemResponse.class)
                .doOnError(this::handleThrowable)
                .map(response -> failIfResponseHasErrors(request, response));
    }
}